### PR TITLE
#19 Retrieve bathPath automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,8 @@ func createUser(c echo.Context) error {
 ## Usage
 #### Create a `ApiRoot` with `New()`, which is a wrapper of `echo.New()`
 ```
-r := echoswagger.New(echo.New(), "/v1", "doc/", nil)
+r := echoswagger.New(echo.New(), "doc/", nil)
 ```
-> Note: The parameter `basePath` is generally used when the access root path is not the root directory of the website after application is deployed. For example, the URL of an API in the program running locally is: `http://localhost:1323/users`, the actual URL after deployed to server is: `https://www.xxx.com/legacy-api/users`, then, when running locally, `basePath` should be `/`, when running on server, `basePath` should be `/legacy-api`.
-
 You can use the result `ApiRoot` instance to:
 - Setup Security definitions, request/response Content-Types, UI options, Scheme, etc.
 ```

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -58,8 +58,6 @@ func createUser(c echo.Context) error {
 ```
 r := echoswagger.New(echo.New(), "/v1", "doc/", nil)
 ```
-> 注意：参数`basePath`一般用于程序部署后访问路径并非网站根目录时的情况，比如程序运行在本地的某个API的URL为：`http://localhost:1323/users`，部署至服务器后的实际URL为：`https://www.xxx.com/legacy-api/users`，则本地运行时，`basePath`应该传入`/`, 部署至服务器时，`basePath`应该传入`/legacy-api`。
-
 你可以用这个`ApiRoot`来：
 - 设置Security定义, 请求/响应Content-Type，UI选项，Scheme等。
 ```

--- a/assets.go
+++ b/assets.go
@@ -47,10 +47,13 @@ const SwaggerUIContent = `{{define "swagger"}}
     <script src="{{.cdn}}/swagger-ui-standalone-preset.js" crossorigin="anonymous"></script>
     <script>
     window.onload = function() {
-
+      var specPath = "{{.specName}}"
+      if (!window.location.pathname.endsWith("/")) {
+        specPath = "/" + specPath
+      }
       // Build a system
       const ui = SwaggerUIBundle({
-        url: this.window.location.origin+{{.path}},
+        url: window.location.origin+window.location.pathname+specPath,
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/examples/main.go
+++ b/examples/main.go
@@ -13,7 +13,7 @@ func main() {
 func initServer() echoswagger.ApiRoot {
 	e := echo.New()
 
-	se := echoswagger.New(e, "", "doc/", &echoswagger.Info{
+	se := echoswagger.New(e, "doc/", &echoswagger.Info{
 		Title:          "Swagger Petstore",
 		Description:    "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters.",
 		Version:        "1.0.0",

--- a/examples/main_test.go
+++ b/examples/main_test.go
@@ -18,7 +18,7 @@ func TestMain(t *testing.T) {
 	c := e.Echo().NewContext(req, rec)
 	b, err := ioutil.ReadFile("./swagger.json")
 	assert.Nil(t, err)
-	if assert.NoError(t, e.(*echoswagger.Root).Spec(c)) {
+	if assert.NoError(t, e.(*echoswagger.Root).SpecHandler("/doc")(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.JSONEq(t, string(b), rec.Body.String())
 	}

--- a/internal.go
+++ b/internal.go
@@ -31,7 +31,7 @@ type RawDefine struct {
 	Schema *JSONSchema
 }
 
-func (r *Root) docHandler(realSpecPath string) echo.HandlerFunc {
+func (r *Root) docHandler() echo.HandlerFunc {
 	t, err := template.New("swagger").Parse(SwaggerUIContent)
 	if err != nil {
 		panic(err)
@@ -43,10 +43,10 @@ func (r *Root) docHandler(realSpecPath string) echo.HandlerFunc {
 		}
 		buf := new(bytes.Buffer)
 		t.Execute(buf, map[string]interface{}{
-			"title":   r.spec.Info.Title,
-			"hideTop": r.ui.HideTop,
-			"path":    realSpecPath,
-			"cdn":     cdn,
+			"title":    r.spec.Info.Title,
+			"hideTop":  r.ui.HideTop,
+			"cdn":      cdn,
+			"specName": SpecName,
 		})
 		return c.HTMLBlob(http.StatusOK, buf.Bytes())
 	}

--- a/security_test.go
+++ b/security_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSecurity(t *testing.T) {
-	r := New(echo.New(), "/", "doc/", nil)
+	r := New(echo.New(), "doc/", nil)
 	scope := map[string]string{
 		"read:users":  "read users",
 		"write:users": "modify users",
@@ -194,7 +194,7 @@ func TestSecurity(t *testing.T) {
 }
 
 func TestSecurityRepeat(t *testing.T) {
-	r := New(echo.New(), "/", "doc/", nil)
+	r := New(echo.New(), "doc/", nil)
 	scope := map[string]string{
 		"read:users":  "read users",
 		"write:users": "modify users",

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,9 @@
 package echoswagger
 
-import "reflect"
+import (
+	"reflect"
+	"strings"
+)
 
 func contains(list []string, s string) bool {
 	for _, t := range list {
@@ -84,4 +87,20 @@ func connectPath(paths ...string) string {
 		result += path
 	}
 	return result
+}
+
+func removeTrailingSlash(path string) string {
+	l := len(path) - 1
+	if l > 0 && strings.HasSuffix(path, "/") {
+		path = path[:l]
+	}
+	return path
+}
+
+func trimSuffixSlash(s, suffix string) string {
+	s = connectPath(s)
+	suffix = connectPath(suffix)
+	s = removeTrailingSlash(s)
+	suffix = removeTrailingSlash(suffix)
+	return strings.TrimSuffix(s, suffix)
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -209,7 +209,7 @@ type api struct {
 
 // New creates ApiRoot instance.
 // Multiple ApiRoot are allowed in one project.
-func New(e *echo.Echo, basePath, docPath string, i *Info) ApiRoot {
+func New(e *echo.Echo, docPath string, i *Info) ApiRoot {
 	if e == nil {
 		panic("echoswagger: invalid Echo instance")
 	}
@@ -225,7 +225,6 @@ func New(e *echo.Echo, basePath, docPath string, i *Info) ApiRoot {
 		spec: &Swagger{
 			Info:                i,
 			SecurityDefinitions: make(map[string]*SecurityDefinition),
-			BasePath:            connectPath(basePath),
 			Definitions:         make(map[string]*JSONSchema),
 		},
 		routers: routers{
@@ -233,10 +232,8 @@ func New(e *echo.Echo, basePath, docPath string, i *Info) ApiRoot {
 		},
 	}
 
-	specPath := connectPath(docPath, "swagger.json")
-	realSpecPath := connectPath(basePath, specPath)
-	e.GET(connectPath(docPath), r.docHandler(realSpecPath))
-	e.GET(specPath, r.Spec)
+	e.GET(connectPath(docPath), r.docHandler())
+	e.GET(connectPath(docPath, SpecName), r.SpecHandler(docPath))
 	return r
 }
 


### PR DESCRIPTION
No need to pass bathPath parameter for `New()`, it should be automatically generated by 'Referer' header or request URI.