### PR TITLE
#29 Support embedded struct type of params

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -19,7 +19,7 @@ func (Items) generate(t reflect.Type) *Items {
 }
 
 func (Parameter) generate(f reflect.StructField, in ParamInType) *Parameter {
-	name := getFieldName(f, in)
+	name, _ := getFieldName(f, in)
 	if name == "-" {
 		return nil
 	}
@@ -41,7 +41,7 @@ func (Parameter) generate(f reflect.StructField, in ParamInType) *Parameter {
 }
 
 func (Header) generate(f reflect.StructField) *Header {
-	name := getFieldName(f, ParamInHeader)
+	name, _ := getFieldName(f, ParamInHeader)
 	if name == "-" {
 		return nil
 	}
@@ -105,7 +105,7 @@ func (api) genHeader(v reflect.Value) map[string]*Header {
 		f := rt.Field(i)
 		h := Header{}.generate(f)
 		if h != nil {
-			name := getFieldName(f, ParamInHeader)
+			name, _ := getFieldName(f, ParamInHeader)
 			mh[name] = h
 		}
 	}

--- a/internal_test.go
+++ b/internal_test.go
@@ -84,17 +84,32 @@ func TestParamTypes(t *testing.T) {
 
 func TestNestedParamTypes(t *testing.T) {
 	var pa struct {
-		Name string
+		ExpiredAt time.Time
+	}
+	type User struct {
+		ExpiredAt time.Time
 	}
 	var pb struct {
-		User struct {
-			Name string
-		}
+		User User
 	}
+	type Org struct {
+		Id      int64  `json:"id"`
+		Address string `json:"address"`
+	}
+	var pc struct {
+		User
+		Org
+	}
+	var pd struct {
+		User
+		Org `json:"org"` // this tag would be ignored
+	}
+
 	tests := []struct {
-		p     interface{}
-		panic bool
-		name  string
+		p      interface{}
+		panic  bool
+		name   string
+		params []string
 	}{
 		{
 			p:     0,
@@ -102,14 +117,27 @@ func TestNestedParamTypes(t *testing.T) {
 			name:  "Basic type",
 		},
 		{
-			p:     pa,
-			panic: false,
-			name:  "Struct type",
+			p:      pa,
+			panic:  false,
+			name:   "Struct type",
+			params: []string{"ExpiredAt"},
 		},
 		{
 			p:     pb,
 			panic: true,
 			name:  "Nested struct type",
+		},
+		{
+			p:      pc,
+			panic:  false,
+			name:   "Embedded struct type",
+			params: []string{"ExpiredAt", "id", "address"},
+		},
+		{
+			p:      pd,
+			panic:  false,
+			name:   "Embedded struct type with tag",
+			params: []string{"ExpiredAt", "id", "address"},
 		},
 	}
 	for _, tt := range tests {
@@ -123,7 +151,12 @@ func TestNestedParamTypes(t *testing.T) {
 				a.AddParamPathNested(tt.p)
 				sapi, ok := a.(*api)
 				assert.Equal(t, ok, true)
-				assert.Equal(t, len(sapi.operation.Parameters), 1)
+				assert.Equal(t, len(sapi.operation.Parameters), len(tt.params))
+				var params []string
+				for _, p := range sapi.operation.Parameters {
+					params = append(params, p.Name)
+				}
+				assert.ElementsMatch(t, params, tt.params)
 			}
 		})
 	}
@@ -235,7 +268,7 @@ type testPet struct {
 	Masters []testUser
 }
 
-func TestRecursiveTypes(t *testing.T) {
+func TestSchemaRecursiveStruct(t *testing.T) {
 	tests := []struct {
 		p    interface{}
 		name string
@@ -260,4 +293,28 @@ func TestRecursiveTypes(t *testing.T) {
 			assert.Equal(t, tt.name, sapi.operation.Parameters[0].Name)
 		})
 	}
+}
+
+func TestSchemaNestedStruct(t *testing.T) {
+	type User struct {
+		ExpiredAt time.Time
+	}
+	type Org struct {
+		Id      int64  `json:"id"`
+		Address string `json:"address"`
+	}
+	var pa struct {
+		User `json:"user"`
+		Org
+	}
+	a := prepareApi()
+	a.AddParamBody(pa, "pa", "", true)
+	sapi, ok := a.(*api)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, len(sapi.operation.Parameters), 1)
+	assert.NotNil(t, (*sapi.defs)[""])
+	assert.NotNil(t, (*sapi.defs)[""].Schema.Properties["address"])
+	assert.NotNil(t, (*sapi.defs)[""].Schema.Properties["id"])
+	assert.NotNil(t, (*sapi.defs)["User"])
+	assert.NotNil(t, (*sapi.defs)["User"].Schema.Properties["ExpiredAt"])
 }

--- a/tag.go
+++ b/tag.go
@@ -34,7 +34,7 @@ func getSwaggerTags(field reflect.StructField) map[string]string {
 	return r
 }
 
-func getFieldName(f reflect.StructField, in ParamInType) string {
+func getFieldName(f reflect.StructField, in ParamInType) (string, bool) {
 	var name string
 	switch in {
 	case ParamInQuery:
@@ -45,9 +45,9 @@ func getFieldName(f reflect.StructField, in ParamInType) string {
 		_, name = getTag(f, "json", 0)
 	}
 	if name != "" {
-		return name
+		return name, true
 	} else {
-		return f.Name
+		return f.Name, false
 	}
 }
 

--- a/validator.go
+++ b/validator.go
@@ -41,7 +41,11 @@ func isValidParam(t reflect.Type, nest, inner bool) bool {
 			return true
 		} else if !inner {
 			for i := 0; i < t.NumField(); i++ {
-				if !isValidParam(t.Field(i).Type, nest, true) {
+				inner := true
+				if t.Field(i).Type.Kind() == reflect.Struct && t.Field(i).Anonymous {
+					inner = false
+				}
+				if !isValidParam(t.Field(i).Type, nest, inner) {
 					return false
 				}
 			}


### PR DESCRIPTION
With this feature, now we support:

```go
type PagingInput struct {
	SkipCount      int `query:"skipCount"`
	MaxResultCount int `query:"maxResultCount"`
}

type SearchInput struct {
	Q    string `query:"q"`
	Code string `query:"code"`
	PagingInput
}

r := echoswagger.New(echo.New(), "/doc", nil)
r.GET("", handler).AddParamQueryNested(SearchInput{})
```